### PR TITLE
Resolve refs to "{{ linkText }}" and "{{ value }}" in Slack message

### DIFF
--- a/SmartThings-SlackWebhook.groovy
+++ b/SmartThings-SlackWebhook.groovy
@@ -229,8 +229,8 @@ def eventHandler(evt) {
   ]
   def json_body = [
       text: evt.descriptionText
-      	.replace("{{ linkText }}", evt.device.displayName ?: 'Device')
-        .replace("{{ value }}", evt.value.toString()),
+          .replace("{{ linkText }}", evt.device.displayName ?: 'Device')
+          .replace("{{ value }}", evt.value.toString()),
       username: evt.displayName,
       attachments: [attachment]
   ]

--- a/SmartThings-SlackWebhook.groovy
+++ b/SmartThings-SlackWebhook.groovy
@@ -228,7 +228,9 @@ def eventHandler(evt) {
     fallback: evt.descriptionText
   ]
   def json_body = [
-      text: evt.descriptionText,
+      text: evt.descriptionText
+      	.replace("{{ linkText }}", evt.device.displayName ?: 'Device')
+        .replace("{{ value }}", evt.value.toString()),
       username: evt.displayName,
       attachments: [attachment]
   ]


### PR DESCRIPTION
Remedies problem with current code whereby references to `linkText` and `value` appear in the Slack message instead of the actual device name and value (if any)